### PR TITLE
Publicación directorios

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+	"name": "knxroot/bdcut-cl",
+	"description": "Chile: 'Códigos territoriales (Región, Provincia, Comuna)'. bdcut-cl es una colección que contiene los códigos y nombres territoriales chilenos en diferentes formatos para ser implementado fácilmente en Bases de datos o proyectos de desarrollo.",
+	"type": "library",
+	"license": "GPL-3.0",
+	"require": {},
+	"authors": [
+		{
+			"name" : "Danilo Lacoste",
+			"email": "danilo@lacosox.org"
+		},
+		{
+			"name": "Gustavo Lacoste",
+			"email": "gustavo@lacosox.org"
+		},
+		{
+			"name": "djuretic",
+			"homepage": "http://github.com/djuretic"
+		},
+		{
+			"name": "Roberto Bufadel Silva",
+			"email": "jjzd2w@gmail.com"
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bdcut-cl",
-	"version": "0.2.2",
+	"version": "0.3",
 	"description": "Chile: 'Códigos territoriales (Región, Provincia, Comuna)'. bdcut-cl es una colección que contiene los códigos y nombres territoriales chilenos en diferentes formatos para ser implementado fácilmente en Bases de datos o proyectos de desarrollo.",
 	"main": "index.js",
 	"repository": "https://github.com/knxroot/bdcut-cl.git",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "bdcut-cl",
+	"version": "0.2.2",
+	"description": "Chile: 'Códigos territoriales (Región, Provincia, Comuna)'. bdcut-cl es una colección que contiene los códigos y nombres territoriales chilenos en diferentes formatos para ser implementado fácilmente en Bases de datos o proyectos de desarrollo.",
+	"main": "index.js",
+	"repository": "https://github.com/knxroot/bdcut-cl.git",
+	"author": {
+	  "name" : "Danilo Lacoste",
+	  "email": "danilo@lacosox.org"
+	},
+	"contributors": [
+		{
+			"name": "Gustavo Lacoste",
+			"email": "gustavo@lacosox.org"
+		},
+		{
+			"name": "djuretic",
+			"url": "http://github.com/djuretic"
+		},
+		{
+			"name": "Roberto Bufadel Silva",
+			"email": "jjzd2w@gmail.com"
+		}
+	],
+	"license": "GPL-3.0",
+	"private": false
+}


### PR DESCRIPTION
Hola!

Las modificaciones son muy sencillas: solamente agregué los archivos de definiciones de paquete para la publicación en npmjs.com (directorio de paquetes de node, que en cierta medida viene a reemplazar a bower), y en [Packagist](http://packagist.org/), que es el repositorio principal de Composer (gestor de paquetes para PHP)

Quedo atento a sus comentarios y gracias por su trabajo y seriedad en este necesario proyecto!